### PR TITLE
fix: keep Jellyfin user_id in profile config across restarts

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,11 +29,11 @@ type Config struct {
 
 // ServerConfig holds media server configuration
 type ServerConfig struct {
-	Type     SourceType `mapstructure:"type"`     // "plex" or "jellyfin"
-	URL      string     `mapstructure:"url"`      // Server URL
-	Token    string     `mapstructure:"token"`    // Plex token OR Jellyfin API key
-	UserID   string     `mapstructure:"user_id"`  // Jellyfin only
-	Username string     `mapstructure:"username"` // Jellyfin only (display)
+	Type     SourceType `mapstructure:"type"     yaml:"type"`     // "plex" or "jellyfin"
+	URL      string     `mapstructure:"url"      yaml:"url"`      // Server URL
+	Token    string     `mapstructure:"token"    yaml:"token"`    // Plex token OR Jellyfin API key
+	UserID   string     `mapstructure:"user_id"  yaml:"user_id"`  // Jellyfin only
+	Username string     `mapstructure:"username" yaml:"username"` // Jellyfin only (display)
 }
 
 // PlayerConfig holds media player configuration


### PR DESCRIPTION
## Summary

- Jellyfin users currently hit `Error: failed to create media client: Jellyfin requires user ID` on the second launch, right after a successful first-launch wizard.
- Root cause: `ServerConfig.UserID` has a `mapstructure:"user_id"` tag but no `yaml:` tag, so yaml.v3 serializes the profile entry with the lowercased Go field name (`userid`). mapstructure then ignores it on reload, the empty-UserID profile overwrites the (correct) top-level `Server`, and Jellyfin client construction fails.
- Fix: add `yaml:` tags matching the `mapstructure:` tags on `ServerConfig` so the marshaled keys are consistent with what the unmarshaler expects.

See https://github.com/AndyHoang/cue/issues/1 (filed against the fork because issues are disabled upstream) for full reproduction and analysis.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/config/...`
- [x] Manual: complete Jellyfin login wizard, quit, relaunch `cue` → app starts without "Jellyfin requires user ID".
- [ ] Inspect `~/.config/cue/config.yaml` and confirm `profiles.default.server.user_id` (snake_case) is written.

## Notes for users with an existing broken config

Existing configs written by a pre-fix build will have `profiles.<name>.server.userid:` (no underscore). After this PR is merged, either:

1. Manually rename `userid:` → `user_id:` once, OR
2. Delete the profile block; the next save will write it correctly.