### PR TITLE
feat: side-load external subtitle tracks into the player

### DIFF
--- a/internal/domain/playback.go
+++ b/internal/domain/playback.go
@@ -2,9 +2,26 @@ package domain
 
 import "context"
 
+// Subtitle describes an external subtitle track that the player should side-load.
+type Subtitle struct {
+	URL      string // Direct URL the player can fetch
+	Language string // ISO language code, e.g. "eng", "spa"
+	Title    string // Human-readable label (may be empty)
+	Codec    string // e.g. "srt", "ass", "vtt"
+	Default  bool   // Server marked this track as default
+	Forced   bool   // Forced subtitle track
+}
+
+// PlayableMedia describes everything the player needs to play an item:
+// the main media URL plus any external (sidecar) subtitle tracks the server exposes.
+type PlayableMedia struct {
+	URL       string
+	Subtitles []Subtitle
+}
+
 // PlaybackClient provides network operations for media playback.
 type PlaybackClient interface {
-	ResolvePlayableURL(ctx context.Context, itemID string) (string, error)
+	ResolvePlayable(ctx context.Context, itemID string) (PlayableMedia, error)
 	MarkPlayed(ctx context.Context, itemID string) error
 	MarkUnplayed(ctx context.Context, itemID string) error
 	// UpdateProgress reports the current playback position to the server.

--- a/internal/mediaserver/jellyfin/client.go
+++ b/internal/mediaserver/jellyfin/client.go
@@ -337,8 +337,9 @@ func (c *Client) Search(ctx context.Context, query string) ([]*domain.MediaItem,
 	return MapSearchResults(resp.SearchHints, c.baseURL), nil
 }
 
-// ResolvePlayableURL returns a direct playback URL for an item
-func (c *Client) ResolvePlayableURL(ctx context.Context, itemID string) (string, error) {
+// ResolvePlayable returns a direct playback URL plus any external subtitle tracks
+// for an item.
+func (c *Client) ResolvePlayable(ctx context.Context, itemID string) (domain.PlayableMedia, error) {
 	// Get playback info to get the stream URL
 	query := url.Values{}
 	query.Set("UserId", c.userID)
@@ -347,26 +348,109 @@ func (c *Client) ResolvePlayableURL(ctx context.Context, itemID string) (string,
 	path := fmt.Sprintf("/Items/%s/PlaybackInfo", itemID)
 	body, err := c.doRequest(ctx, http.MethodGet, path, query)
 	if err != nil {
-		return "", err
+		return domain.PlayableMedia{}, err
 	}
 
 	var resp PlaybackInfoResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return "", fmt.Errorf("failed to parse response: %w", err)
+		return domain.PlayableMedia{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
 	if len(resp.MediaSources) == 0 {
-		return "", domain.ErrItemNotFound
+		return domain.PlayableMedia{}, domain.ErrItemNotFound
 	}
 
 	source := resp.MediaSources[0]
 
 	// Build direct stream URL
-	// Format: /Videos/{itemId}/stream.{container}?static=true&api_key={token}
+	// Format: /Videos/{itemId}/stream.{container}?Static=true&api_key={token}
 	streamURL := fmt.Sprintf("%s/Videos/%s/stream.%s?Static=true&api_key=%s",
 		c.baseURL, itemID, source.Container, c.token)
 
-	return streamURL, nil
+	subs := c.collectExternalSubtitles(itemID, source)
+	if len(subs) > 0 {
+		c.logger.Debug("resolved external subtitles", "itemID", itemID, "count", len(subs))
+	}
+
+	return domain.PlayableMedia{URL: streamURL, Subtitles: subs}, nil
+}
+
+// collectExternalSubtitles builds a list of side-loadable subtitle tracks
+// from the media source's stream list. Embedded tracks are skipped because
+// the player picks them up from the container directly.
+func (c *Client) collectExternalSubtitles(itemID string, source MediaSource) []domain.Subtitle {
+	if len(source.MediaStreams) == 0 {
+		return nil
+	}
+
+	subs := make([]domain.Subtitle, 0)
+	for _, stream := range source.MediaStreams {
+		if stream.Type != "Subtitle" {
+			continue
+		}
+		// Embedded subtitles travel inside the container and don't need a sub-file.
+		if !stream.IsExternal && !strings.EqualFold(stream.DeliveryMethod, "External") {
+			continue
+		}
+
+		codec := strings.ToLower(stream.Codec)
+		ext := codec
+		if ext == "" {
+			ext = "srt"
+		}
+
+		// Prefer the server-provided DeliveryUrl when present; otherwise build the
+		// canonical /Videos/{item}/{src}/Subtitles/{idx}/Stream.{codec} URL.
+		var subURL string
+		switch {
+		case stream.DeliveryURL != "":
+			subURL = c.absolutize(stream.DeliveryURL)
+			subURL = appendAPIKey(subURL, c.token)
+		default:
+			subURL = fmt.Sprintf("%s/Videos/%s/%s/Subtitles/%d/Stream.%s?api_key=%s",
+				c.baseURL, itemID, source.ID, stream.Index, ext, c.token)
+		}
+
+		subs = append(subs, domain.Subtitle{
+			URL:      subURL,
+			Language: stream.Language,
+			Title:    firstNonEmpty(stream.DisplayTitle, stream.Title),
+			Codec:    codec,
+			Default:  stream.IsDefault,
+			Forced:   stream.IsForced,
+		})
+	}
+	return subs
+}
+
+func (c *Client) absolutize(u string) string {
+	if strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://") {
+		return u
+	}
+	if !strings.HasPrefix(u, "/") {
+		u = "/" + u
+	}
+	return c.baseURL + u
+}
+
+func appendAPIKey(u, token string) string {
+	if token == "" {
+		return u
+	}
+	sep := "?"
+	if strings.Contains(u, "?") {
+		sep = "&"
+	}
+	return u + sep + "api_key=" + token
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // GetMediaItem returns detailed metadata for a specific item

--- a/internal/mediaserver/jellyfin/dto.go
+++ b/internal/mediaserver/jellyfin/dto.go
@@ -101,18 +101,25 @@ type MediaSource struct {
 
 // MediaStream represents a video, audio, or subtitle stream
 type MediaStream struct {
-	Codec        string `json:"Codec"`
-	Language     string `json:"Language,omitempty"`
-	DisplayTitle string `json:"DisplayTitle,omitempty"`
-	Type         string `json:"Type"` // "Video", "Audio", "Subtitle"
-	Index        int    `json:"Index"`
-	IsDefault    bool   `json:"IsDefault"`
-	Height       int    `json:"Height,omitempty"`
-	Width        int    `json:"Width,omitempty"`
-	BitRate      int    `json:"BitRate,omitempty"`
-	Channels     int    `json:"Channels,omitempty"`
-	SampleRate   int    `json:"SampleRate,omitempty"`
-	AspectRatio  string `json:"AspectRatio,omitempty"`
+	Codec                  string `json:"Codec"`
+	Language               string `json:"Language,omitempty"`
+	DisplayTitle           string `json:"DisplayTitle,omitempty"`
+	Title                  string `json:"Title,omitempty"`
+	Type                   string `json:"Type"` // "Video", "Audio", "Subtitle"
+	Index                  int    `json:"Index"`
+	IsDefault              bool   `json:"IsDefault"`
+	IsForced               bool   `json:"IsForced,omitempty"`
+	IsExternal             bool   `json:"IsExternal,omitempty"`
+	IsTextSubtitleStream   bool   `json:"IsTextSubtitleStream,omitempty"`
+	SupportsExternalStream bool   `json:"SupportsExternalStream,omitempty"`
+	DeliveryMethod         string `json:"DeliveryMethod,omitempty"` // "Embed", "External", "Hls", "Encode"
+	DeliveryURL            string `json:"DeliveryUrl,omitempty"`
+	Height                 int    `json:"Height,omitempty"`
+	Width                  int    `json:"Width,omitempty"`
+	BitRate                int    `json:"BitRate,omitempty"`
+	Channels               int    `json:"Channels,omitempty"`
+	SampleRate             int    `json:"SampleRate,omitempty"`
+	AspectRatio            string `json:"AspectRatio,omitempty"`
 }
 
 // PlaybackInfoResponse contains playback information for an item

--- a/internal/mediaserver/plex/client.go
+++ b/internal/mediaserver/plex/client.go
@@ -291,36 +291,98 @@ func (c *Client) Search(ctx context.Context, query string) ([]*domain.MediaItem,
 	return MapOnDeck(container.Metadata, c.baseURL), nil
 }
 
-// ResolvePlayableURL returns a direct playback URL for an item
-func (c *Client) ResolvePlayableURL(ctx context.Context, itemID string) (string, error) {
+// ResolvePlayable returns a direct playback URL plus any external subtitle
+// tracks for an item.
+func (c *Client) ResolvePlayable(ctx context.Context, itemID string) (domain.PlayableMedia, error) {
 	path := fmt.Sprintf("/library/metadata/%s", itemID)
 	body, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return "", err
+		return domain.PlayableMedia{}, err
 	}
 
 	container, err := c.parseResponse(body)
 	if err != nil {
-		return "", err
+		return domain.PlayableMedia{}, err
 	}
 
 	if len(container.Metadata) == 0 {
-		return "", domain.ErrItemNotFound
+		return domain.PlayableMedia{}, domain.ErrItemNotFound
 	}
 
 	// Extract media URL from the metadata
 	m := container.Metadata[0]
 	if len(m.Media) == 0 || len(m.Media[0].Part) == 0 {
-		return "", domain.ErrItemNotFound
+		return domain.PlayableMedia{}, domain.ErrItemNotFound
 	}
 
-	mediaPath := m.Media[0].Part[0].Key
-	if mediaPath == "" {
-		return "", domain.ErrItemNotFound
+	part := m.Media[0].Part[0]
+	if part.Key == "" {
+		return domain.PlayableMedia{}, domain.ErrItemNotFound
 	}
 
-	// Add token to URL for direct play
-	return fmt.Sprintf("%s%s?X-Plex-Token=%s", c.baseURL, mediaPath, c.token), nil
+	mediaURL := fmt.Sprintf("%s%s?X-Plex-Token=%s", c.baseURL, part.Key, c.token)
+	subs := c.collectExternalSubtitles(part)
+	if len(subs) > 0 {
+		c.logger.Debug("resolved external subtitles", "itemID", itemID, "count", len(subs))
+	}
+
+	return domain.PlayableMedia{URL: mediaURL, Subtitles: subs}, nil
+}
+
+// collectExternalSubtitles extracts external subtitle streams from a Plex Part.
+// Embedded subtitle streams (no Key, External!=1) are skipped because the player
+// reads them from the container directly.
+func (c *Client) collectExternalSubtitles(part Part) []domain.Subtitle {
+	if len(part.Stream) == 0 {
+		return nil
+	}
+	subs := make([]domain.Subtitle, 0)
+	for _, s := range part.Stream {
+		if s.StreamType != 3 { // 3 = subtitle
+			continue
+		}
+		// Only external streams expose a fetchable Key. Embedded streams have
+		// no separate URL and the player will discover them in the container.
+		if s.External != 1 && s.Key == "" {
+			continue
+		}
+		if s.Key == "" {
+			continue
+		}
+
+		sep := "?"
+		if strings.Contains(s.Key, "?") {
+			sep = "&"
+		}
+		subURL := fmt.Sprintf("%s%s%sX-Plex-Token=%s", c.baseURL, s.Key, sep, c.token)
+
+		lang := s.LanguageCode
+		if lang == "" {
+			lang = s.Language
+		}
+		title := s.DisplayTitle
+		if title == "" {
+			title = s.ExtendedDisplayTitle
+		}
+		if title == "" {
+			title = s.Title
+		}
+
+		codec := strings.ToLower(s.Codec)
+		if codec == "" {
+			codec = strings.ToLower(s.Format)
+		}
+
+		subs = append(subs, domain.Subtitle{
+			URL:      subURL,
+			Language: lang,
+			Title:    title,
+			Codec:    codec,
+			Default:  s.Default == 1,
+			Forced:   s.Forced == 1,
+		})
+	}
+	return subs
 }
 
 // GetMediaItem returns detailed metadata for a specific item

--- a/internal/mediaserver/plex/dto.go
+++ b/internal/mediaserver/plex/dto.go
@@ -106,13 +106,33 @@ type Media struct {
 
 // Part represents a media file part
 type Part struct {
-	ID        int    `json:"id"`
-	Key       string `json:"key"`
-	Duration  int    `json:"duration,omitempty"`
-	File      string `json:"file,omitempty"`
-	Size      int64  `json:"size,omitempty"`
-	Container string `json:"container,omitempty"`
-	Stream    []any  `json:"Stream,omitempty"`
+	ID        int      `json:"id"`
+	Key       string   `json:"key"`
+	Duration  int      `json:"duration,omitempty"`
+	File      string   `json:"file,omitempty"`
+	Size      int64    `json:"size,omitempty"`
+	Container string   `json:"container,omitempty"`
+	Stream    []Stream `json:"Stream,omitempty"`
+}
+
+// Stream represents a video, audio, or subtitle stream inside a Plex Part.
+// streamType: 1 = video, 2 = audio, 3 = subtitle.
+type Stream struct {
+	ID                   int    `json:"id"`
+	StreamType           int    `json:"streamType"`
+	Key                  string `json:"key,omitempty"`     // e.g. "/library/streams/12345" for external subs
+	Codec                string `json:"codec,omitempty"`
+	Format               string `json:"format,omitempty"`
+	Language             string `json:"language,omitempty"`
+	LanguageCode         string `json:"languageCode,omitempty"`
+	LanguageTag          string `json:"languageTag,omitempty"`
+	DisplayTitle         string `json:"displayTitle,omitempty"`
+	ExtendedDisplayTitle string `json:"extendedDisplayTitle,omitempty"`
+	Title                string `json:"title,omitempty"`
+	Default              int    `json:"default,omitempty"`
+	Forced               int    `json:"forced,omitempty"`
+	Selected             int    `json:"selected,omitempty"`
+	External             int    `json:"external,omitempty"`
 }
 
 // APIResponse wraps the MediaContainer for JSON unmarshaling

--- a/internal/player/launcher.go
+++ b/internal/player/launcher.go
@@ -59,20 +59,21 @@ func NewLauncher(command string, args []string, seekFlag string, logger *slog.Lo
 	}
 }
 
-// Launch opens a media URL in the configured player or auto-detected player
-func (l *Launcher) Launch(url string, startOffset time.Duration) (*exec.Cmd, string, error) {
+// Launch opens a media URL in the configured player or auto-detected player.
+// Any external subtitle tracks in `media` are side-loaded into mpv-family players.
+func (l *Launcher) Launch(media domain.PlayableMedia, startOffset time.Duration) (*exec.Cmd, string, error) {
 	offsetSecs := int(startOffset.Seconds())
 
 	// Tier 1: User configured a specific player
 	if l.command != "" {
 		l.logger.Info("using configured player", "command", l.command)
-		return l.launchConfigured(url, offsetSecs)
+		return l.launchConfigured(media, offsetSecs)
 	}
 
 	// Tier 2: Auto-detect known players
 	if player, found := l.detectPlayer(); found {
 		l.logger.Info("auto-detected player", "binary", player.Binary)
-		return l.execPlayer(player, url, offsetSecs)
+		return l.execPlayer(player, media, offsetSecs)
 	}
 
 	// Tier 3: System default fallback (xdg-open/open)
@@ -80,8 +81,55 @@ func (l *Launcher) Launch(url string, startOffset time.Duration) (*exec.Cmd, str
 	if offsetSecs > 0 {
 		l.logger.Warn("resume not supported with system default player - starting from beginning")
 	}
-	cmd, err := l.launchDefault(url)
+	if len(media.Subtitles) > 0 {
+		l.logger.Warn("external subtitles not supported with system default player - some tracks may be missing")
+	}
+	cmd, err := l.launchDefault(media.URL)
 	return cmd, "", err
+}
+
+// subFileArgs returns the player-specific args needed to side-load each external
+// subtitle. Returns nil when the binary has no known sub-file flag.
+func subFileArgs(binary string, subs []domain.Subtitle) []string {
+	if len(subs) == 0 {
+		return nil
+	}
+	bin := strings.ToLower(filepath.Base(binary))
+	switch bin {
+	case "mpv", "iina", "celluloid", "haruna":
+		// mpv, IINA and other mpv-frontends accept multiple --sub-file flags.
+		// IINA's CLI is `iina-cli`, but mpv-passthrough flags also work via
+		// the `--mpv-` prefix used in seek flags; --sub-file works directly
+		// for mpv/celluloid/haruna. IINA accepts `--mpv-sub-file=` too.
+		prefix := "--sub-file="
+		if bin == "iina" {
+			prefix = "--mpv-sub-file="
+		}
+		args := make([]string, 0, len(subs))
+		for _, s := range subs {
+			if s.URL == "" {
+				continue
+			}
+			args = append(args, prefix+s.URL)
+		}
+		return args
+	case "vlc":
+		// VLC supports only a single :sub-file. If the user has multiple,
+		// pick the default (or first) so they at least get one.
+		pick := subs[0]
+		for _, s := range subs {
+			if s.Default {
+				pick = s
+				break
+			}
+		}
+		if pick.URL == "" {
+			return nil
+		}
+		return []string{":sub-file=" + pick.URL}
+	default:
+		return nil
+	}
 }
 
 // detectPlayer returns the first available player from the platform-specific list
@@ -106,7 +154,7 @@ func (l *Launcher) detectPlayer() (PlayerDef, bool) {
 }
 
 // execPlayer launches the detected player with optional seek offset
-func (l *Launcher) execPlayer(player PlayerDef, url string, offsetSecs int) (*exec.Cmd, string, error) {
+func (l *Launcher) execPlayer(player PlayerDef, media domain.PlayableMedia, offsetSecs int) (*exec.Cmd, string, error) {
 	args := []string{}
 	var ipcSocket string
 
@@ -123,7 +171,14 @@ func (l *Launcher) execPlayer(player PlayerDef, url string, offsetSecs int) (*ex
 		args = append(args, strings.Fields(formattedFlag)...)
 	}
 
-	args = append(args, url)
+	if subArgs := subFileArgs(player.Binary, media.Subtitles); len(subArgs) > 0 {
+		args = append(args, subArgs...)
+	} else if len(media.Subtitles) > 0 {
+		l.logger.Warn("external subtitles not supported by player - skipping",
+			"binary", player.Binary, "count", len(media.Subtitles))
+	}
+
+	args = append(args, media.URL)
 
 	l.logger.Debug("executing player", "binary", player.Binary, "args", args)
 	cmd := exec.Command(player.Binary, args...)
@@ -134,7 +189,7 @@ func (l *Launcher) execPlayer(player PlayerDef, url string, offsetSecs int) (*ex
 }
 
 // launchConfigured launches the media using the user-configured player
-func (l *Launcher) launchConfigured(url string, offsetSecs int) (*exec.Cmd, string, error) {
+func (l *Launcher) launchConfigured(media domain.PlayableMedia, offsetSecs int) (*exec.Cmd, string, error) {
 	args := append([]string{}, l.args...)
 
 	// Add seek offset: user-configured flag takes precedence, then table lookup
@@ -154,7 +209,14 @@ func (l *Launcher) launchConfigured(url string, offsetSecs int) (*exec.Cmd, stri
 		}
 	}
 
-	args = append(args, url)
+	if subArgs := subFileArgs(l.command, media.Subtitles); len(subArgs) > 0 {
+		args = append(args, subArgs...)
+	} else if len(media.Subtitles) > 0 {
+		l.logger.Warn("external subtitles not supported by configured player - skipping",
+			"command", l.command, "count", len(media.Subtitles))
+	}
+
+	args = append(args, media.URL)
 
 	l.logger.Debug("launching configured player", "command", l.command, "args", args)
 
@@ -263,15 +325,16 @@ func (s *Service) Resume(ctx context.Context, item domain.MediaItem) (PlaybackHa
 
 // playItem resolves URL and launches player
 func (s *Service) playItem(ctx context.Context, item domain.MediaItem, offset time.Duration) (PlaybackHandle, error) {
-	url, err := s.playback.ResolvePlayableURL(ctx, item.ID)
+	media, err := s.playback.ResolvePlayable(ctx, item.ID)
 	if err != nil {
 		s.logger.Error("failed to resolve playable URL", "error", err, "itemID", item.ID)
 		return PlaybackHandle{}, err
 	}
 
-	s.logger.Info("launching playback", "title", item.Title, "itemID", item.ID, "offset", offset)
+	s.logger.Info("launching playback",
+		"title", item.Title, "itemID", item.ID, "offset", offset, "subtitles", len(media.Subtitles))
 
-	cmd, ipcSocket, err := s.launcher.Launch(url, offset)
+	cmd, ipcSocket, err := s.launcher.Launch(media, offset)
 	if err != nil {
 		return PlaybackHandle{}, err
 	}


### PR DESCRIPTION
## Summary

- External subtitle tracks (sidecar `.srt`/`.ass`/`.vtt`, forced/SDH variants, etc.) the server stores outside the container were never reaching the player, so users only got embedded subs.
- Cause: `ResolvePlayableURL` returned a single video URL; the launcher never passed any `--sub-file=` args; and the Plex `Part.Stream` field was untyped (`[]any`), so subtitle metadata wasn't even parsed.
- This PR introduces `domain.PlayableMedia` (URL + `[]Subtitle`), teaches both backends to enumerate external subtitle streams, and side-loads each track into mpv/IINA/celluloid/haruna; VLC gets the default/first; unknown players warn and skip.

See https://github.com/AndyHoang/cue/issues/2 for the full analysis.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] Manual (Jellyfin): play a movie with at least one external `.srt`/`.ass` track and confirm it appears in mpv's track menu (`#`/`j` cycles tracks).
- [x] Manual (Jellyfin): play a movie with only embedded subs — they still work, no regression.
- [ ] Manual (Plex): play an item where the server has uploaded external subs and confirm the same.
- [ ] Logs show `executing player` / `launching configured player` with `--sub-file=...` args, and the `launching playback` line includes a non-zero `subtitles` count.

## Notes

- Image-based subs (PGS/SUP) that Jellyfin's `/Subtitles/.../Stream.{codec}` endpoint can't serve simply won't load — playback still works.
- Interface change is internal (`PlaybackClient.ResolvePlayableURL` → `ResolvePlayable`); no external consumers.
- Stacks cleanly on top of #1 but doesn't depend on it.